### PR TITLE
Fix: 카카오 간편 로그인 외부 프론트 테스트 호스트 -> 배포 호스트로 변경

### DIFF
--- a/src/back-end/timepay/src/main/java/com/capstone/timepay/service/user/service/KakaoLoginService.java
+++ b/src/back-end/timepay/src/main/java/com/capstone/timepay/service/user/service/KakaoLoginService.java
@@ -44,7 +44,7 @@ public class KakaoLoginService {
             sb.append("&client_id=79587b639a3a9ca1c9433fa63bc55863");
             //sb.append("&redirect_uri=http://localhost:8080/oauth/redirect/kakao"); // 서버 로컬 테스트용
             //sb.append("&redirect_uri=http://localhost:3000/oauth/redirect/kakao"); // 프론트 로컬 테스트용
-            sb.append("&redirect_uri=http://54.180.107.93:3000/oauth/redirect/kakao"); // 배포할 때 이 코드 사용
+            sb.append("&redirect_uri=http://13.125.249.51/oauth/redirect/kakao"); // 배포할 때 이 코드 사용
 
 
             sb.append("&code=" + code);


### PR DESCRIPTION
## What's Changed?
- 카카오 간편 로그인 외부 프론트 테스트 호스트 -> 배포 호스트로 변경

## Screenshots
