### PR TITLE
[사용자] 게시글 상태 변경 api 연결

### DIFF
--- a/src/front-end/timepay-front/src/api/hooks/board.ts
+++ b/src/front-end/timepay-front/src/api/hooks/board.ts
@@ -10,6 +10,7 @@ import {
 import { apiRequest } from '../request';
 import { API_URL } from '../urls';
 import { useMutation, useQuery } from 'react-query';
+import { api } from '../../services';
 
 export const useInfiniteGetSearchBoard = (params: IGetSearchBoardRequest) => {
   return useInfiniteQuery<AxiosResponse<IGetSearchBoardResponse>, AxiosError>({
@@ -60,5 +61,19 @@ export const useCreateReports = () => {
       apiRequest.post(API_URL.FREE_BOARDS_WRITE, {
         ...data,
       }),
+  });
+};
+
+export const usePutBoardStateStart = (postPk: number) => {
+  return useMutation<AxiosResponse<any>, AxiosError>({
+    mutationKey: 'usePutBoardState',
+    mutationFn: () => apiRequest.put(`${API_URL.DEAL_BOARDS}/${postPk}/start`),
+  });
+};
+
+export const usePutBoardStateFinish = (postPk: number) => {
+  return useMutation<AxiosResponse<any>, AxiosError>({
+    mutationKey: 'usePutBoardState',
+    mutationFn: () => apiRequest.put(`${API_URL.DEAL_BOARDS}/${postPk}/finish`),
   });
 };

--- a/src/front-end/timepay-front/src/api/interfaces/IPost.ts
+++ b/src/front-end/timepay-front/src/api/interfaces/IPost.ts
@@ -75,8 +75,8 @@ export interface IReportBoard {
 }
 
 export type IPostState =
-  | '매칭중'
-  | '매칭완료'
+  | '모집중'
+  | '모집완료'
   | '활동중'
   | '활동완료'
   | '활동지연'

--- a/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
+++ b/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
@@ -18,11 +18,11 @@ const PostStatusTag = ({ status }: { status?: string | null | undefined }) => {
 
   const statusColor: PostStatusTagColorProps = useMemo(() => {
     switch (getStatus(currentStatus)) {
-      case '매칭중':
+      case '모집중':
         return {
           pointColor: COMMON_COLOR.MAIN1,
         };
-      case '매칭완료':
+      case '모집완료':
         return {
           pointColor: COMMON_COLOR.FONT2,
         };

--- a/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
+++ b/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
@@ -1,5 +1,5 @@
 import { Tag } from 'antd';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useFontSize from '../../hooks/useFontSize';
 import { COMMON_COLOR } from '../../styles/constants/colors';
 import { getStatus } from '../../utils/board';
@@ -9,10 +9,13 @@ export interface PostStatusTagColorProps {
   pointColor: string;
   backgroundColor?: string;
 }
+
 const PostStatusTag = ({ status }: { status?: string | null }) => {
   const { scaleValue } = useFontSize();
+  const [currentStatus, setCurrentStatus] = useState<string | null>(null);
+
   const statusColor: PostStatusTagColorProps = useMemo(() => {
-    switch (getStatus(status)) {
+    switch (getStatus(currentStatus)) {
       case '매칭중':
         return {
           pointColor: COMMON_COLOR.MAIN1,
@@ -39,10 +42,16 @@ const PostStatusTag = ({ status }: { status?: string | null }) => {
           pointColor: COMMON_COLOR.FONT2,
         };
     }
+  }, [currentStatus]);
+
+  useEffect(() => {
+    setCurrentStatus(status);
+    console.log('status', status);
   }, [status]);
+
   return (
     <Tag css={cssPostStatusTagStyle(statusColor, scaleValue)}>
-      {getStatus(status) || '로딩 중'}
+      {getStatus(currentStatus) || '로딩 중'}
     </Tag>
   );
 };

--- a/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
+++ b/src/front-end/timepay-front/src/components/PostStatusTag/PostStatusTag.tsx
@@ -10,9 +10,11 @@ export interface PostStatusTagColorProps {
   backgroundColor?: string;
 }
 
-const PostStatusTag = ({ status }: { status?: string | null }) => {
+const PostStatusTag = ({ status }: { status?: string | null | undefined }) => {
   const { scaleValue } = useFontSize();
-  const [currentStatus, setCurrentStatus] = useState<string | null>(null);
+  const [currentStatus, setCurrentStatus] = useState<string | null | undefined>(
+    null,
+  );
 
   const statusColor: PostStatusTagColorProps = useMemo(() => {
     switch (getStatus(currentStatus)) {
@@ -46,7 +48,6 @@ const PostStatusTag = ({ status }: { status?: string | null }) => {
 
   useEffect(() => {
     setCurrentStatus(status);
-    console.log('status', status);
   }, [status]);
 
   return (

--- a/src/front-end/timepay-front/src/components/post/ApplicantButton.tsx
+++ b/src/front-end/timepay-front/src/components/post/ApplicantButton.tsx
@@ -8,7 +8,15 @@ import {
 } from '../../pages/PostPage/PostPage.style';
 import { COMMON_COLOR } from '../../styles/constants/colors';
 
-export const ApplicantButton = ({ applicantList, onItemClick }) => {
+interface ApplicantButtonProps {
+  applicantList: string[];
+  onItemClick: (index: number, name: string) => void;
+}
+
+const ApplicantButton: React.FC<ApplicantButtonProps> = ({
+  applicantList,
+  onItemClick,
+}) => {
   const [isListModalOpen, setIsListModalOpen] = useState(false);
   const [selectedApplicantIndex, setSelectedApplicantIndex] = useState(-1);
   const [messageApi, contextHolder] = message.useMessage();
@@ -37,13 +45,12 @@ export const ApplicantButton = ({ applicantList, onItemClick }) => {
     setIsListModalOpen(false);
   };
 
-  const onItemClickHandler = (index) => {
+  const onItemClickHandler = (index: number) => {
     setSelectedApplicantIndex(index);
   };
 
   return (
     <div css={cssCommentContainer}>
-      <p>댓글</p>
       {contextHolder}
       <div css={cssCollectButton}>
         <Button css={cssCollectBtn} onClick={showListModal}>
@@ -83,3 +90,5 @@ export const ApplicantButton = ({ applicantList, onItemClick }) => {
     </div>
   );
 };
+
+export default ApplicantButton;

--- a/src/front-end/timepay-front/src/components/post/PostButton.style.tsx
+++ b/src/front-end/timepay-front/src/components/post/PostButton.style.tsx
@@ -25,7 +25,7 @@ export const cssPostButton = css`
     background-color: ${COMMON_COLOR.MAIN1};
   }
   &.completed {
-    width: 45%;
+    width: 95%;
     background-color: #ff4910;
     margin-right: 6px;
   }

--- a/src/front-end/timepay-front/src/components/post/PostButton.tsx
+++ b/src/front-end/timepay-front/src/components/post/PostButton.tsx
@@ -20,19 +20,19 @@ const PostButton = () => {
   );
 
   const [buttonState, setButtonState] = useState<string>(() => {
-    const storedState = localStorage.getItem('buttonState');
+    const storedState = localStorage.getItem(`buttonState_${real_id}`);
     return storedState ? storedState : 'start';
   });
   const [buttonText, setButtonText] = useState<string>(() => {
-    const storedText = localStorage.getItem('buttonText');
+    const storedText = localStorage.getItem(`buttonText_${real_id}`);
     return storedText ? storedText : '활동시작';
   });
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    localStorage.setItem('buttonState', buttonState);
-    localStorage.setItem('buttonText', buttonText);
-  }, [buttonState, buttonText]);
+    localStorage.setItem(`buttonState_${real_id}`, buttonState);
+    localStorage.setItem(`buttonText_${real_id}`, buttonText);
+  }, [buttonState, buttonText, real_id]);
 
   const startActivity = useCallback(async () => {
     try {

--- a/src/front-end/timepay-front/src/components/post/PostButton.tsx
+++ b/src/front-end/timepay-front/src/components/post/PostButton.tsx
@@ -108,6 +108,8 @@ const PostButton = () => {
         title="활동을 시작하시겠습니까?"
         open={isModalOpen}
         onOk={handleConfirm}
+        okText="활동 시작"
+        cancelText="취소"
         onCancel={handleCancel}
         style={{ fontWeight: 400 }}
       >
@@ -116,9 +118,11 @@ const PostButton = () => {
         </h3>
       </Modal>
       <Modal
-        title="활동을 종료하시겠습니까?"
+        title="활동을 완료하시겠습니까?"
         open={isModalOpen2}
         onOk={handleConfirm}
+        okText="활동 완료"
+        cancelText="취소"
         onCancel={handleCancel}
         style={{ fontWeight: 400 }}
       >

--- a/src/front-end/timepay-front/src/components/post/PostButton.tsx
+++ b/src/front-end/timepay-front/src/components/post/PostButton.tsx
@@ -1,43 +1,60 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Modal } from 'antd';
 import { cssPostButton, cssPostButtons } from './PostButton.style';
 
+import {
+  usePutBoardStateStart,
+  usePutBoardStateFinish,
+} from '../../api/hooks/board';
+import { useMutation, useQueryClient } from 'react-query';
+
 const PostButton = () => {
+  const queryClient = useQueryClient();
+  const url = window.location.pathname;
+  const real_id = url.substring(6);
+  const usePutBoardStateStartMutation = usePutBoardStateStart(
+    parseInt(real_id),
+  );
+  const usePutBoardStateFinishMutation = usePutBoardStateFinish(
+    parseInt(real_id),
+  );
+
   const [buttonState, setButtonState] = useState<string>('start');
+  const [buttonText, setButtonText] = useState<string>('활동시작');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const buttonText = useMemo(() => {
-    switch (buttonState) {
-      case 'start':
-        return '활동시작';
-      case 'completed':
-        return '활동완료';
-      case 'deleted':
-        return '활동취소';
-      case 'theEnd':
-        return '활동이 종료된 게시글입니다 :)';
-      default:
-        return '';
-    }
-  }, [buttonState]);
+  // const buttonText = useMemo(() => {
+  //   switch (buttonState) {
+  //     case 'start'
+  //       return '활동시작';
+  //     case 'completed':
+  //       return '활동완료';
+  //     case 'deleted':
+  //       return '활동취소';
+  //     case 'theEnd':
+  //       return '활동이 종료된 게시글입니다 :)';
+  //     default:
+  //       return '';
+  //   }
+  // }, [buttonState]);
 
-  const onClickButton = (): void => {
-    switch (buttonState) {
-      case 'start':
-        setButtonState('completed');
-        break;
-      case 'completed':
-        setButtonState('theEnd');
-        break;
-      case 'deleted':
-        setButtonState('theEnd');
-        break;
-      case 'theEnd':
-        break;
-      default:
-        break;
-    }
-  };
+  // const onClickButton = (): void => {
+  //   switch (buttonState) {
+  //     case 'start':
+  //       setButtonState('completed');
+  //       break;
+  //     case 'completed':
+  //       setButtonState('theEnd');
+  //       break;
+  //     case 'deleted':
+  //       setButtonState('theEnd');
+  //       break;
+  //     case 'theEnd':
+  //       break;
+  //     default:
+  //       break;
+  //   }
+  // };
 
   const showModal = () => {
     if (buttonState === 'completed') {
@@ -55,6 +72,28 @@ const PostButton = () => {
     setIsModalOpen(false);
   };
 
+  const startActivity = useCallback(async () => {
+    try {
+      await usePutBoardStateStartMutation.mutateAsync();
+      queryClient.invalidateQueries('');
+      setButtonState('completed');
+      setButtonText('활동완료');
+    } catch (error) {
+      console.error('start에서 오류가 발생했습니다.', error);
+    }
+  }, [buttonState, queryClient, buttonText]);
+
+  const finishActivity = useCallback(async () => {
+    try {
+      await usePutBoardStateFinishMutation.mutateAsync();
+      queryClient.invalidateQueries('');
+      setButtonState('theEnd');
+      setButtonText('활동이 종료된 게시글입니다 :)');
+    } catch (error) {
+      console.error('finish에서 오류가 발생했습니다.', error);
+    }
+  }, [buttonState, queryClient, buttonText]);
+
   return (
     <>
       <div css={cssPostButtons}>
@@ -62,8 +101,7 @@ const PostButton = () => {
           <button
             css={cssPostButton}
             onClick={() => {
-              onClickButton();
-              // showModal();
+              startActivity();
             }}
             className={`${buttonState}`}
           >
@@ -74,7 +112,7 @@ const PostButton = () => {
             <button
               css={cssPostButton}
               onClick={() => {
-                setButtonState('theEnd');
+                finishActivity();
                 showModal();
               }}
               className="completed"
@@ -84,7 +122,7 @@ const PostButton = () => {
             <button
               css={cssPostButton}
               onClick={() => {
-                setButtonState('theEnd');
+                finishActivity();
               }}
               className="deleted"
             >
@@ -95,7 +133,6 @@ const PostButton = () => {
           <button
             css={cssPostButton}
             onClick={() => {
-              onClickButton();
               showModal();
             }}
             className={`${buttonState}`}

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.style.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.style.tsx
@@ -241,11 +241,21 @@ export const cssApplicant = css`
 `;
 
 // footer
-export const cssPostFooter = css`
+export const cssAuthorFooter = css`
   box-shadow: 0px -5px 2px 3px rgb(255, 255, 255, 0.5);
   position: fixed;
   width: 100%;
   height: 160px;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  background-color: ${COMMON_COLOR.WHITE};
+`;
+export const cssNonAuthorFooter = css`
+  box-shadow: 0px -5px 2px 3px rgb(255, 255, 255, 0.5);
+  position: fixed;
+  width: 100%;
+  height: 95px;
   bottom: 0;
   margin: 0;
   padding: 0;

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.style.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.style.tsx
@@ -50,6 +50,13 @@ export const cssPostDetailPage = css`
   display: flex;
   flex-direction: column;
   margin-top: 20px;
+  h1 {
+    font-size: 22px;
+    font-weight: 500;
+    margin: 0;
+    margin-top: 40px;
+    margin-left: 20px;
+  }
 `;
 
 // 1st block
@@ -209,12 +216,6 @@ export const cssCommentContainer = css`
   margin-top: 10px;
   margin-left: 25px;
   margin-right: 25px;
-  p {
-    font-size: 22px;
-    font-weight: 500;
-    margin: 0;
-    margin-top: 20px;
-  }
 `;
 export const cssCollectButton = css`
   display: flex;

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
@@ -48,7 +48,7 @@ import { apiRequest } from '../../api/request';
 import { API_URL } from '../../api/urls';
 import Item from '../../components/post/Item';
 import InputText from '../../components/post/InputText';
-import { ApplicantButton } from '../../components/post/ApplicantButton';
+import ApplicantButton from '../../components/post/ApplicantButton';
 
 import axios from 'axios';
 import { useDeleteBoard, useGetBoard } from '../../api/hooks/board';
@@ -400,10 +400,13 @@ const PostPage = () => {
           </div>
         </div>
         <div css={cssLine4} />
-        <ApplicantButton
-          applicantList={applicantList}
-          onItemClick={onApplicantClick}
-        />
+        <h1>댓글</h1>
+        {author && (
+          <ApplicantButton
+            applicantList={applicantList}
+            onItemClick={onApplicantClick}
+          />
+        )}
         <div css={cssPostDetailSixth}>
           {applicants.length > 0 ? (
             applicants.map((data) => (

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
@@ -110,9 +110,11 @@ const PostPage = () => {
   const comments = useGetComments(parseInt(real_id));
   const useDeleteCommentMutation = useDeleteComment();
 
+  const [postState, setPostState] = useState();
   useEffect(() => {
-    console.log(data?.data.state);
-  }, [data?.data.state]);
+    setPostState(data?.data.state);
+    console.log(postState);
+  }, [data?.data.state, postState]);
 
   useEffect(() => {
     apiRequest
@@ -426,13 +428,12 @@ const PostPage = () => {
       </div>
       <Footer css={author ? cssAuthorFooter : cssNonAuthorFooter}>
         <div css={cssLine2} />
-        {author && (
+        {author || postState === 'ACTIVITY_COMPLETE' ? (
           <>
             <PostButton />
             <div css={cssLine5} />
           </>
-        )}
-
+        ) : null}
         <div css={cssPostFooter2}>
           <InputText onChange={handleInputTextChange} inputText={inputText} />
           <button css={cssPostBtn} onClick={handleSubmitComment}>

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
@@ -56,8 +56,7 @@ import {
   useGetComments,
   useDeleteComment,
 } from '../../api/hooks/comment';
-import { useMutation } from 'react-query';
-import { useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 import { PATH } from '../../utils/paths';
 import { COMMON_COLOR } from '../../styles/constants/colors';
@@ -109,6 +108,10 @@ const PostPage = () => {
   const createCommentMutation = useCreateComment(parseInt(real_id));
   const comments = useGetComments(parseInt(real_id));
   const useDeleteCommentMutation = useDeleteComment();
+
+  useEffect(() => {
+    console.log(data?.data.state);
+  }, [data?.data.state]);
 
   useEffect(() => {
     apiRequest

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
@@ -24,7 +24,8 @@ import {
   cssPostDetailAttachment,
   cssReportContainer,
   cssReportBtnStyle,
-  cssPostFooter,
+  cssAuthorFooter,
+  cssNonAuthorFooter,
   cssPostDetail,
   cssLine2,
   cssPostBtn,
@@ -420,10 +421,15 @@ const PostPage = () => {
           )}
         </div>
       </div>
-      <Footer css={cssPostFooter}>
+      <Footer css={author ? cssAuthorFooter : cssNonAuthorFooter}>
         <div css={cssLine2} />
-        <PostButton />
-        <div css={cssLine5} />
+        {author && (
+          <>
+            <PostButton />
+            <div css={cssLine5} />
+          </>
+        )}
+
         <div css={cssPostFooter2}>
           <InputText onChange={handleInputTextChange} inputText={inputText} />
           <button css={cssPostBtn} onClick={handleSubmitComment}>

--- a/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
+++ b/src/front-end/timepay-front/src/pages/PostPage/PostPage.tsx
@@ -428,12 +428,20 @@ const PostPage = () => {
       </div>
       <Footer css={author ? cssAuthorFooter : cssNonAuthorFooter}>
         <div css={cssLine2} />
-        {author || postState === 'ACTIVITY_COMPLETE' ? (
+        {author && (
           <>
             <PostButton />
             <div css={cssLine5} />
           </>
-        ) : null}
+        )}
+
+        {!author && postState === 'ACTIVITY_COMPLETE' && (
+          <>
+            <PostButton />
+            <div css={cssLine5} />
+          </>
+        )}
+
         <div css={cssPostFooter2}>
           <InputText onChange={handleInputTextChange} inputText={inputText} />
           <button css={cssPostBtn} onClick={handleSubmitComment}>

--- a/src/front-end/timepay-front/src/utils/board.ts
+++ b/src/front-end/timepay-front/src/utils/board.ts
@@ -7,9 +7,9 @@ export const getStatus: (boardStatus?: string | null) => IPostState = (
   if (boardStatus)
     switch (boardStatus) {
       case 'MATCHING_IN_PROGRESS':
-        return '매칭중';
+        return '모집중';
       case 'MATCHING_COMPLETE':
-        return '매칭완료';
+        return '모집완료';
       case 'ACTIVITY_IN_PROGRESS':
         return '활동중';
       case 'ACTIVITY_COMPLETE':
@@ -19,9 +19,9 @@ export const getStatus: (boardStatus?: string | null) => IPostState = (
       case 'ACTIVITY_CANCEL':
         return '활동취소';
       default:
-        return '매칭중';
+        return '모집중';
     }
-  else return '매칭중';
+  else return '모집중';
 };
 
 export const getType: (type?: string) => IPostType = (type?: string) => {


### PR DESCRIPTION
## What's Changed?
- 게시글 상태 변경 api 연결했습니다.
- 현재 작성자에게만 게시글 상태 버튼이 보이고, 활동이 종료되었다는 안내문구는 모두에게 보이게 했습니다.
- 버튼을 누르면 게시글의 상태에 바로 반영되어 보여집니다.
- 매칭중,매칭완료 상태명을 모집중,모집완료 로 변경하였는데 이전 상태명이 나으면 다시 변경하겠습니다.
- 게시글 상태를 localstorage에 저장해서 게시글 상태를 유지했는데 이 방법이 괜찮을지도 한 번 확인 부탁드립니다.
- 버튼을 클릭할 때마다 확인 모달창이 뜨도록 했습니다.

## Screenshots
<img width="385" alt="image" src="https://github.com/kookmin-sw/capstone-2023-09/assets/66265618/d71210cb-b960-447c-a841-46c0f7bd4caa">
<img width="385" alt="image" src="https://github.com/kookmin-sw/capstone-2023-09/assets/66265618/6d875745-1c94-4654-b595-6559c1f48f91">

